### PR TITLE
added level feature

### DIFF
--- a/NumerAlpha.class.php
+++ b/NumerAlpha.class.php
@@ -24,6 +24,7 @@ class NumerAlpha {
 	);
 	static $frame = null; // set with each use of parser function...
 	static $prevName = 'default'; // default counter name
+	static $prevLevel = 0; //default level 0
 	static $lists = array();
 	static $listTypes = null;
 
@@ -86,7 +87,7 @@ class NumerAlpha {
 						}
 						break;
 					case wfMessage( 'ext-numeralpha-list-set-label' )->text():
-						$newCountValue = intVal( $value );
+						if ($value != '') $newCountValue = intVal( $value );
 						break;
 					case wfMessage( 'ext-numeralpha-list-pad-length' )->text():
 						self::$lists[ $name ][ 'padlength' ] = intVal( $value );
@@ -100,12 +101,21 @@ class NumerAlpha {
 					case wfMessage( 'ext-numeralpha-list-suffix' )->text():
 						self::$lists[ $name ][ 'suffix' ] = $value;
 						break;
+					case wfMessage( 'ext-numeralpha-list-level-label' )->text():
+						self::$lists[ $name ][ 'level' ] = intVal($value);
+						break;
 				}
 
 			}
 
 		}
-
+		
+		if (isset(self::$lists[$name]['level']))
+		{
+			if (self::$lists[$name]['level'] > self::$prevLevel) $newCountValue = 1;
+			self::$prevLevel = self::$lists[$name]['level'];
+		}
+		
 		// either set count value or increment existing value
 		if ( isset( $newCountValue ) ) {
 			self::$lists[ $name ][ 'count' ] = $newCountValue;

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -13,5 +13,6 @@
 	"ext-numeralpha-list-pad-length": "pad length",
 	"ext-numeralpha-list-pad-char": "pad character",
 	"ext-numeralpha-list-prefix": "prefix",
-	"ext-numeralpha-list-suffix": "suffix"
+	"ext-numeralpha-list-suffix": "suffix",
+	"ext-numeralpha-list-level-label": "level"
 }


### PR DESCRIPTION
added feature to use different numbering levels.

Example: 

:{{#counter:L1|type=numeral|level=1|set=}}. hello
:{{#counter:L1|type=numeral|level=1|set=}}. world
::{{#counter:L2|type=alpha|level=2|set=}}. goodbye
::{{#counter:L2|type=alpha|level=2|set=}}. world
:{{#counter:L1|type=numeral|level=1|set=}}. jupiter
::{{#counter:L2|type=alpha|level=2|set=}}. jazz
:::{{#counter:L3|type=roman|level=3|set=}}. testing
::::{{#counter:L4|type=numeral|level=4|set=}}. whoa
:::::{{#counter:L5|type=alpha|level=5|set=}}. dude
::::{{#counter:L4|type=numeral|level=4|set=}}. stuff
::::{{#counter:L4|type=numeral|level=4|set=6}}. more
